### PR TITLE
Bump Forge & Groovy versions, slightly improve readme and mods.groovy

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -33,7 +33,7 @@ as `loaderVersion`.
 
 The main mod class should have a no-arg constructor and be annotated with `@GMod` with the mod ID specified. Access to the mod and Forge
 buses is provided respectively through the `modBus` or `forgeBus` properties.
-If you want `@CompileStatic` support for those properties, consider implementing `BaseGMod` in your mod main class.
+If you want IDE support alongside `@CompileStatic` for those properties, consider implementing `BaseGMod` in your mod main class or install the EnhancedGroovy plugin for IntelliJ.
 
 ```groovy
 @GMod('examplemod')
@@ -51,7 +51,7 @@ class ExampleMod implements BaseGMod {
 
 ## Groovy Version
 
-The Groovy version provided by GML is: **4.0.5**.  
+The Groovy version provided by GML is: **4.0.6**.  
 The specific Groovy version a GML version provides can be found in the `META-INF/MANIFEST.MF` file in the jar, the `BundledGroovyVersion` property.
 
 Only releases will be supported by GML, not release candidates.

--- a/README.MD
+++ b/README.MD
@@ -28,12 +28,12 @@ plugins {
     id 'groovy'
 }
 ```
-In your `mods.toml` / `mods.groovy`, specify `gml` as the loader and the version of the software
+In your `mods.toml` / [mods.groovy](https://github.com/GroovyMC/ModsDotGroovy), specify `gml` as the loader and the version of the software
 as `loaderVersion`.
 
 The main mod class should have a no-arg constructor and be annotated with `@GMod` with the mod ID specified. Access to the mod and Forge
 buses is provided respectively through the `modBus` or `forgeBus` properties.
-If you want IDE support alongside `@CompileStatic` for those properties, consider implementing `BaseGMod` in your mod main class or install the EnhancedGroovy plugin for IntelliJ.
+If you want IDE support alongside `@CompileStatic` for those properties, consider implementing `BaseGMod` in your mod main class or install the [EnhancedGroovy plugin for IntelliJ](https://plugins.jetbrains.com/plugin/19844-enhancedgroovy).
 
 ```groovy
 @GMod('examplemod')
@@ -50,12 +50,12 @@ class ExampleMod implements BaseGMod {
 ```
 
 ## Groovy Version
-
-The Groovy version provided by GML is: **4.0.6**.  
-The specific Groovy version a GML version provides can be found in the `META-INF/MANIFEST.MF` file in the jar, the `BundledGroovyVersion` property.
+The Groovy version provided by the latest version of GML is currently: **4.0.6**.  
+To find out what Groovy version a built GML jar provides, you can read the `BundledGroovyVersion` property in the `META-INF/MANIFEST.MF`.
 
 Only releases will be supported by GML, not release candidates.
 Once a Forge version has a Recommended Build published, the Groovy major and minor versions will be locked for that Minecraft version. However, patch versions will still be updated.
+
 ### Groovy modules
 The Groovy modules provided by GML are: stdlib, contracts, datetime, nio, macro, macro-library, templates, typecheckers, dateutil, ginq, toml, json.  
 You may however include a Groovy module that is **not** provided by GML using [JiJ](https://forge.gemwire.uk/wiki/Jar-in-Jar).  

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,16 @@ org.gradle.daemon=false
 org.gradle.console=verbose
 
 # Dependencies
-forge_version=43.0.11
+forge_version=43.1.1
 mc_version=1.19.2
 cgl_version=0.1.1
 
 # Groovy
-groovy_version=4.0.5
+groovy_version=4.0.6
 groovy_next_major=5.0.0
 
 # Self versions
-version=1.2.1
+version=1.3.0
 scriptmods_version=1.0.0
 
 # CurseForge

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=false
 org.gradle.console=verbose
 
 # Dependencies
-forge_version=43.1.1
+forge_version=43.1.55
 mc_version=1.19.2
 cgl_version=0.1.1
 

--- a/src/mod/resources/mods.groovy
+++ b/src/mod/resources/mods.groovy
@@ -7,7 +7,7 @@ ModsDotGroovy.make {
 
     mod {
         modId = 'gml'
-        author = 'Matyrobbrt'
+        authors = ['Matyrobbrt', 'Paint_Ninja']
         displayName = 'GroovyModLoader'
         version = this.version
         description = 'A mod loader for Groovy mods'

--- a/src/mod/resources/mods.groovy
+++ b/src/mod/resources/mods.groovy
@@ -9,6 +9,7 @@ ModsDotGroovy.make {
         modId = 'gml'
         authors = ['Matyrobbrt', 'Paint_Ninja']
         displayName = 'GroovyModLoader'
+        displayUrl = 'https://www.curseforge.com/minecraft/mc-mods/gml?projectId=661517'
         version = this.version
         description = 'A mod loader for Groovy mods'
         logoFile = 'gml.png'

--- a/templates/README.MD
+++ b/templates/README.MD
@@ -28,12 +28,12 @@ plugins {
     id 'groovy'
 }
 ```
-In your `mods.toml` / `mods.groovy`, specify `gml` as the loader and the version of the software
+In your `mods.toml` / [mods.groovy](https://github.com/GroovyMC/ModsDotGroovy), specify `gml` as the loader and the version of the software
 as `loaderVersion`.
 
 The main mod class should have a no-arg constructor and be annotated with `@GMod` with the mod ID specified. Access to the mod and Forge
 buses is provided respectively through the `modBus` or `forgeBus` properties.
-If you want `@CompileStatic` support for those properties, consider implementing `BaseGMod` in your mod main class.
+If you want IDE support alongside `@CompileStatic` for those properties, consider implementing `BaseGMod` in your mod main class or install the [EnhancedGroovy plugin for IntelliJ](https://plugins.jetbrains.com/plugin/19844-enhancedgroovy).
 
 ```groovy
 @GMod('examplemod')
@@ -50,12 +50,12 @@ class ExampleMod implements BaseGMod {
 ```
 
 ## Groovy Version
-
-The Groovy version provided by GML is: **${groovyVersion}**.  
-The specific Groovy version a GML version provides can be found in the `META-INF/MANIFEST.MF` file in the jar, the `BundledGroovyVersion` property.
+The Groovy version provided by the latest version of GML is currently: **${groovyVersion}**.  
+To find out what Groovy version a built GML jar provides, you can read the `BundledGroovyVersion` property in the `META-INF/MANIFEST.MF`.
 
 Only releases will be supported by GML, not release candidates.
 Once a Forge version has a Recommended Build published, the Groovy major and minor versions will be locked for that Minecraft version. However, patch versions will still be updated.
+
 ### Groovy modules
 The Groovy modules provided by GML are: ${groovyLibs}.  
 You may however include a Groovy module that is **not** provided by GML using [JiJ](https://forge.gemwire.uk/wiki/Jar-in-Jar).  


### PR DESCRIPTION
Supersedes #8, fixes #1. To be merged after #4, #6 and #7.

- Bumps Forge to 43.1.55 to fix the crash on launch on clients from CGL 0.1.0 (https://github.com/GroovyMC/CommonGroovyLibrary/issues/1)
- Bumps Groovy to 4.0.6
- Added displayUrl to the main mods.groovy
- Edited the readme template and ran the makeReadme Gradle task with some minor improvements, such as:
    - Links to mods.groovy and EnhancedGroovy
    - Slightly clearer wording regarding bundled Groovy versions