### PR TITLE
Port to 1.19.3, misc. improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,7 @@ project.ext.manifestAttr = [
         'BundledGroovyVersion'  : project.groovy_version,
         'GitCommit'             : getGitCommit(),
         'FMLModType'            : 'LANGPROVIDER',
-        'Built-on-Minecraft'    : project.mc_version,
-        'DownloadHomepage'      : 'https://www.curseforge.com/minecraft/mc-mods/gml/files'
+        'Built-on-Minecraft'    : project.mc_version
 ]
 
 apply from: 'gradle/projectSetup.gradle'
@@ -66,7 +65,10 @@ repositories {
         name = 'Modding Inquisition Snapshots'
         url = 'https://maven.moddinginquisition.org/snapshots'
     }
-    maven { url = 'https://maven.moddinginquisition.org/releases' }
+    maven {
+        name = 'Modding Inquisition Releases'
+        url = 'https://maven.moddinginquisition.org/releases'
+    }
 }
 
 jij.onConfiguration('groovy') {
@@ -98,7 +100,7 @@ dependencies {
 
     modCompileOnly sourceSets.main.output
 
-    compileOnly 'com.matyrobbrt.enhancedgroovy:dsl:0.1.0'
+    compileOnly 'com.matyrobbrt.enhancedgroovy:dsl:0.2.0'
     include("io.github.groovymc.cgl:cgl-${mc_version}-forge:${cgl_version}") {
         jij.onDependency(it as Dependency) {
             versionRange nextMajor
@@ -175,7 +177,7 @@ tasks.named('jijtestJar', ForgeJarInJarTask).configure {
 }
 
 static String getGitCommit() {
-    def proc = 'git rev-parse --short HEAD'.execute()
+    final proc = 'git rev-parse --short HEAD'.execute()
     proc.waitFor()
-    return proc.exitValue()? "ERROR(${proc.exitValue()})" : proc.text.trim()
+    return proc.exitValue() ? "ERROR(${proc.exitValue()})" : proc.text.trim()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,10 +6,10 @@ org.gradle.console=verbose
 # Dependencies
 forge_version=44.0.37
 mc_version=1.19.3
-cgl_version=0.2.0
+cgl_version=0.2.1
 
 # Groovy
-groovy_version=4.0.6
+groovy_version=4.0.7
 groovy_next_major=5.0.0
 
 # Self versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.daemon=false
 org.gradle.console=verbose
 
 # Dependencies
-forge_version=43.1.55
-mc_version=1.19.2
-cgl_version=0.1.1
+forge_version=44.0.37
+mc_version=1.19.3
+cgl_version=0.2.0
 
 # Groovy
 groovy_version=4.0.6

--- a/gradle/jars.gradle
+++ b/gradle/jars.gradle
@@ -48,11 +48,11 @@ tasks.register('testJar', Jar) {
     from sourceSets.test.output
     classifier 'test'
     manifest.attributes([
-            'Specification-Title': 'no',
+            'Specification-Title': 'GMLTestMod',
             'Specification-Vendor': 'Matyrobbrt',
             'Specification-Version': '1',
-            'Implementation-Title': 'test',
-            'Implementation-Version': '12.12',
+            'Implementation-Title': 'GMLTestMod',
+            'Implementation-Version': '1.0',
             'Implementation-Vendor': 'Matyrobbrt'
     ])
 }

--- a/gradle/mdg.gradle
+++ b/gradle/mdg.gradle
@@ -16,7 +16,7 @@ buildscript {
 apply plugin: ModsDotGroovy
 
 modsDotGroovy {
-    dslVersion = '1.1.3' // Can be replaced with any existing DSL version
+    dslVersion = '1.2.1'
     automaticConfiguration = false
 }
 tasks.create('testModsDotGroovyToToml', ConvertToTomlTask) {

--- a/gradle/minecraft.gradle
+++ b/gradle/minecraft.gradle
@@ -1,5 +1,5 @@
 minecraft {
-    mappings channel: 'parchment', version: '1.18.2-2022.07.17-1.19'
+    mappings channel: 'parchment', version: '2022.12.18-1.19.3'
     runs {
         client {}
         server {}
@@ -20,11 +20,11 @@ dependencies {
         )
     }
 }
+
 tasks.whenTaskAdded {
     if (it.name == 'runClient' || it.name == 'runServer') {
         it.dependsOn(':fullJar')
-    }
-    if (it.name == 'runJijtest') {
+    } else if (it.name == 'runJijtest') {
         it.dependsOn(':jijtestJar')
     }
 }

--- a/src/main/resources/enhancedgroovy/_com.matyrobbrt.gml.GMod.groovy
+++ b/src/main/resources/enhancedgroovy/_com.matyrobbrt.gml.GMod.groovy
@@ -7,14 +7,19 @@
 import com.matyrobbrt.enhancedgroovy.dsl.ClassTransformer
 
 ((ClassTransformer) this.transformer).tap {
-    it.addField([
-            'name': 'modBus',
-            'type': 'com.matyrobbrt.gml.bus.GModEventBus',
-            'modifiers': ['private', 'final']
-    ])
-    it.addField([
-            'name': 'forgeBus',
-            'type': 'net.minecraftforge.eventbus.api.IEventBus',
-            'modifiers': ['private', 'final']
-    ])
+    addField name: 'modBus',
+             type: 'com.matyrobbrt.gml.bus.GModEventBus',
+             modifiers: ['private', 'final']
+
+    addField name: 'forgeBus',
+             type: 'net.minecraftforge.eventbus.api.IEventBus',
+             modifiers: ['private', 'final']
+
+    addMethod name: 'getModBus',
+              returnType: 'com.matyrobbrt.gml.bus.GModEventBus',
+              modifiers: ['private', 'final']
+
+    addMethod name: 'getForgeBus',
+              returnType: 'net.minecraftforge.eventbus.api.IEventBus',
+              modifiers: ['private', 'final']
 }

--- a/src/mod/resources/mods.groovy
+++ b/src/mod/resources/mods.groovy
@@ -16,7 +16,7 @@ ModsDotGroovy.make {
 
         dependencies {
             forge = "[${this.forgeVersion},)"
-            minecraft = this.minecraftVersionRange
+            minecraft = '[1.19.3]'
         }
     }
 }

--- a/src/mod/resources/pack.mcmeta
+++ b/src/mod/resources/pack.mcmeta
@@ -1,8 +1,8 @@
 {
     "pack": {
         "description": "GML Mod resources",
-        "pack_format": 9,
-        "forge:resource_pack_format": 9,
+        "pack_format": 12,
+        "forge:resource_pack_format": 12,
         "forge:data_pack_format": 10
     }
 }

--- a/src/test/resources/mods.groovy
+++ b/src/test/resources/mods.groovy
@@ -4,9 +4,9 @@ ModsDotGroovy.make {
     license = 'MIT'
 
     mod {
-        modId = 'testmod'
-        author = 'me'
-        displayName = 'no'
+        modId = 'gmltestmod'
+        author = 'Matyrobbrt'
+        displayName = 'GML Test Mod'
         version = '1.0'
     }
 }


### PR DESCRIPTION
- Port to 1.19.3
- Update to EnhancedGroovy 0.2.0, add getModBus() and getForgeBus() IDE hints
- Update parchment mappings, forge, mods.groovy, CGL

Depends on mods.groovy's 1.2.1 DSL being merged to fix displayUrl and updateJsonUrl mods.toml generation.