### PR TITLE
Tweak dynamic remapper for 1.19.3

### DIFF
--- a/src/main/groovy/com/matyrobbrt/gml/mappings/MappingsProvider.groovy
+++ b/src/main/groovy/com/matyrobbrt/gml/mappings/MappingsProvider.groovy
@@ -147,7 +147,7 @@ class MappingsProvider {
             officialParser.parse()
 
             // official class name, official -> srg
-            final methodsMap = new LinkedHashMap<String, Map<String, List<String>>>(8000)
+            final methodsMap = new LinkedHashMap<String, Map<String, List<String>>>(8250)
             final fieldsMap = new LinkedHashMap<String, Map<String, String>>(6500)
 
             final methods = new LinkedHashMap<String, List<String>>()

--- a/src/main/groovy/com/matyrobbrt/gml/mappings/OfficialParser.groovy
+++ b/src/main/groovy/com/matyrobbrt/gml/mappings/OfficialParser.groovy
@@ -17,10 +17,10 @@ class OfficialParser implements Closeable {
     final Reader reader
 
     // obf class name to map of official -> obf names
-    final Map<String, Map<String, List<String>>> methods = new LinkedHashMap<>(8750)
-    final Map<String, Map<String, String>> fields = new LinkedHashMap<>(8750)
+    final Map<String, Map<String, List<String>>> methods = new LinkedHashMap<>(9000)
+    final Map<String, Map<String, String>> fields = new LinkedHashMap<>(9000)
     // official -> obf
-    final Map<String, String> classes = new LinkedHashMap<>(8750)
+    final Map<String, String> classes = new LinkedHashMap<>(9000)
 
     private Map<String, List<String>> workingMethods
     private Map<String, String> workingFields

--- a/src/main/groovy/com/matyrobbrt/gml/mappings/SrgParser.groovy
+++ b/src/main/groovy/com/matyrobbrt/gml/mappings/SrgParser.groovy
@@ -14,10 +14,10 @@ class SrgParser implements Closeable {
     final Reader reader
 
     // obf class name to map of obf -> srg names
-    // initial capacity is 9000 because on 1.19.2, max size ends up being 6859. Adding 25% to account for the Map's
+    // initial capacity is 9000 because on 1.19.3, max size ends up being 7135. Adding 25% to account for the Map's
     // default load factor and rounding *up* to the nearest 250. Re-adjust this every MC release for better performance.
-    final Map<String, Map<String, String>> methods = new LinkedHashMap<>(8750)
-    final Map<String, Map<String, String>> fields = new LinkedHashMap<>(8750)
+    final Map<String, Map<String, String>> methods = new LinkedHashMap<>(9000)
+    final Map<String, Map<String, String>> fields = new LinkedHashMap<>(9000)
 
     private Map<String, String> workingMethods
     private Map<String, String> workingFields


### PR DESCRIPTION
Changes the initial capacities to account for 1.19.3 instead of 1.19.2